### PR TITLE
QA-3961 Check whether more limited nodetype than "nt:base" on query

### DIFF
--- a/src/main/resources/jnt_tagCloud/html/tagCloud.jsp
+++ b/src/main/resources/jnt_tagCloud/html/tagCloud.jsp
@@ -32,7 +32,7 @@
         <c:if test="${edit && empty currentNode.properties.resultPage}"><p><fmt:message key="warn.no.searchResultPage"/></p></c:if>
 
     <query:definition var="listQuery" scope="request">
-        <query:selector nodeTypeName="nt:base"/>
+        <query:selector nodeTypeName="jmix:tagged"/>
         <query:descendantNode path="${currentNode.properties['relative'].boolean ? boundComponent.path : renderContext.site.path}"/>
         <query:column columnName="rep:facet(nodetype=jmix:tagged&key=j:tagList&facet.mincount=${usageThreshold}&facet.limit=${numberOfTagsLimit}&facet.sort=true)" propertyName="j:tagList"/>
     </query:definition>


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/QA-3961

## Description

These modification contain the following changes:
- The j:type property is used to determine the type to use instead of nt:base. If it cannot be properly resolved (for example because forked JSPs have not been updated) it will fallback to nt:base
- The FacetChoiceListInitializer has been improved to display only the properties for the j:type selected in the facet list. Also, hidden properties will no longer be displayed.
- Facet URL generation was modified to add a N-type-NODENAME URL query parameter that encodes the j:type value so that the list query may behave properly. This change requires updating forked JSP.
- The jmix:tagged type was added to the list of allowed types when selecting a facet type (note: it might be interesting to add more)
- The tag cloud was also improved to replace its usage of nt:base with jmix:tagged. Again, if this JSP was forked in projects it will require updating.


## Checklist

Impact of these changes for QA:
- Re-test all facet-related features (all facet types)
- Re-test tag clouds

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [x] Migration
- [x] Code maintainability

## Documentation

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [x] User-facing Documentation
