### PR TITLE
fix: render the tag-management screen only for callers administering the resource

### DIFF
--- a/.chachalog/LZ4LS.md
+++ b/.chachalog/LZ4LS.md
@@ -1,0 +1,5 @@
+---
+tags: patch
+---
+
+Render the tag-management screen only for callers administering the resource

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,30 @@
     
     <build>
         <plugins>
+            <!-- DO NOT REMOVE without checking the built jar first.
+                 This module inherits the jahia-modules 8.0.1.0 parent, which does not switch on bnd's DS
+                 annotation scanning. Without this instruction an @Component class compiles and ships but
+                 produces no OSGI-INF descriptor and no Service-Component header, so the component never
+                 registers or activates — it fails SILENTLY, and here that would mean the settings-component
+                 permission filter simply does not run. Measured on this module: with the instruction the jar
+                 contains OSGI-INF/org.jahia.modules.tags.SettingsComponentPermissionFilter.xml; without it,
+                 nothing.
+                 Jahia's shared `cortex` harness documents both the rule and this trap — skill
+                 `jahia-java-osgi-declarative-services`: DS is the only DI mechanism allowed in a Jahia
+                 module, and "without <_dsannotations> @Component classes compile but produce no descriptor
+                 — nothing registers or activates". Diagnose with Karaf `scr:list`: a component missing
+                 entirely (rather than UNSATISFIED) means the annotations were never scanned.
+                 Parents >= 8.1.7.0 enable this already, so this block can go when the parent is bumped. -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <_dsannotations>*</_dsannotations>
+                    </instructions>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>

--- a/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
@@ -91,10 +91,14 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
 
     @Activate
     public void activate() {
-        // Priority 22: immediately after core's own permission check (TemplatePermissionCheckFilter, 21) and
-        // before the fragment is produced or cached — a refusal must not populate a cache entry that a
-        // differently-privileged caller could later be served.
-        setPriority(22);
+        // Priority 21.5: immediately after core's own permission check (TemplatePermissionCheckFilter, 21) and
+        // clear of the 22.x template band. AbstractFilter breaks a priority tie on the class name, so an exact
+        // 22 would order this against core's templateNodeFilter (22.0) by an accident of package naming rather
+        // than by intent; 21.5 states the intended slot instead of relying on that.
+        // This runs inside the fragment cache's generation scope (live only, 16 / 16.5), which is safe because
+        // that cache keys on the caller's ACL signature: an entry generated for an administrator is not served
+        // to a caller who lacks the grant.
+        setPriority(21.5f);
         setApplyOnNodeTypes(APPLY_ON_NODE_TYPES);
         setDescription("Renders a settings component only for a caller holding an administration permission "
                 + "on the main resource");

--- a/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
@@ -13,6 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Wiring note — this is deliberately OSGi Declarative Services, not a Spring bean.
+ *
+ * Jahia's engineering conventions (the shared `cortex` harness, skill
+ * `jahia-java-osgi-declarative-services`) state the rule as: DS is the ONLY dependency-injection
+ * mechanism allowed in a Jahia module — Blueprint is deprecated and Spring is forbidden, with the sole
+ * tolerated exception being a guarded `SpringContextSingleton.getBean(...)` read-through to a core bean.
+ * An earlier revision of this filter was registered as a Spring bean in META-INF/spring; it was moved
+ * here to follow that rule, and the render filter it registers behaves identically either way (both end
+ * up in JahiaTemplateManagerService.getRenderFilters()).
+ *
+ * The same harness documents the trap to watch for if this is ever ported to another module: without the
+ * bnd instruction `<_dsannotations>*</_dsannotations>`, an @Component class compiles and ships but emits
+ * no OSGI-INF descriptor and no Service-Component header, so the component silently never registers and
+ * the gate below simply does not run. Parents `jahia-modules` >= 8.1.7.0 switch it on already; older ones
+ * do not. Verify a descriptor is actually in the built jar rather than assuming.
+ */
 package org.jahia.modules.tags;
 
 import org.apache.commons.lang.StringUtils;
@@ -21,78 +38,83 @@ import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
 import org.jahia.services.render.filter.AbstractFilter;
 import org.jahia.services.render.filter.RenderChain;
+import org.jahia.services.render.filter.RenderFilter;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
- * Renders a settings component only when the caller holds an administration permission on the
- * resource the request is actually made against.
+ * Renders a settings component only when the caller holds an administration permission on the resource the
+ * request is actually made against.
  * <p>
  * The tag-management screen is an ordinary, instantiable content type, so the settings container it was
  * designed for is not the only place it can be rendered from. The permission requirement is declared on the
- * settings <em>template</em> that hosts it ({@code j:requiredPermissionNames}) and is therefore a property of
- * that template: the same component rendered through any other resource — a plain page content area — carries
- * no requirement at all, and the web flow behind it would be handed to whoever can render that resource. This
+ * settings <em>template</em> that hosts it ({@code j:applyOn=jnt:virtualsite},
+ * {@code j:requiredPermissionNames=tagManager}), so it is a property of that template and not of the
+ * component: the same component rendered through any other resource — a plain page content area — carries no
+ * requirement at all, and the web flow behind it would be handed to whoever can render that resource. This
  * filter makes the requirement a property of the component, so it holds on every render path.
  * <p>
  * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
- * node, and for this screen that is essential rather than incidental. Its settings template applies on
- * {@code jnt:virtualsite} under {@code tagManager}, so this is a <em>site-scoped</em> screen and a site
- * administrator is its legitimate caller. That role is granted on {@code /sites/<key>}, while the component
- * node of the legitimate screen lives inside the hosting module ({@code /modules/...}), where they hold
- * nothing — measured, {@code site-admin} is {@code false} on the component node and {@code true} on the site.
- * Checking the component node, which is the obvious implementation, would therefore refuse real site
- * administrators; the main resource is the site itself.
+ * node, and that is load-bearing rather than incidental: the component node of a <em>legitimate</em> settings
+ * screen lives inside its module ({@code /modules/...}), where a site-scoped administrator holds nothing —
+ * measured, {@code site-admin} is {@code false} there and {@code true} on {@code /sites/<key>}. Checking
+ * the component node, which is the obvious implementation, would therefore refuse real site administrators.
+ * The main resource is the site (site-settings route) or the global settings node (server-administration
+ * route), which is what the corresponding administrator role is actually granted on.
  * <p>
- * {@code admin} is accepted alongside {@code site-admin} so a server administrator reaching the screen is not
- * refused either. Both are core permissions
- * ({@code root-permissions.xml}) granted by the {@code site-administrator} / {@code server-administrator}
- * roles; the finer per-screen requirement remains enforced on the administration route by the template, so
- * this filter is an additional condition and never a replacement. Failing to resolve a main resource, or a
- * missing configuration, yields an empty fragment rather than a rendered component.
+ * The screen is site-scoped ({@code j:applyOn=jnt:virtualsite}), so a site administrator is its legitimate
+ * caller and {@code site-admin} must be accepted; {@code admin} is accepted alongside it so a server
+ * administrator is not refused either. Both are core permissions ({@code root-permissions.xml}).
+ * The finer per-screen requirement declared on the settings template remains enforced on the administration
+ * route, so this filter is an additional condition and never a replacement. Failing to resolve a main resource
+ * yields an empty fragment rather than a rendered component.
+ * <p>
+ * Registered via OSGi Declarative Services — no Spring context involvement.
  */
-// equals/hashCode are deliberately NOT overridden for the field below: AbstractFilter defines equality as
-// (concrete class, priority), which is the key RenderService.addFilter uses to replace an already-registered
-// filter. Widening it to the configuration would break that re-registration.
-@SuppressWarnings("java:S2160")
+@Component(service = RenderFilter.class, immediate = true)
 public class SettingsComponentPermissionFilter extends AbstractFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(SettingsComponentPermissionFilter.class);
 
-    private String[] requiredPermissions = new String[0];
-    private String requiredPermissionsLabel = "";
+    /** Node types gated by this filter. */
+    private static final String APPLY_ON_NODE_TYPES = "jnt:tagsManager";
 
-    /**
-     * Sets the permissions accepted by this filter, as a comma-separated list. A caller holding any one of
-     * them on the main resource may render the component.
-     *
-     * @param requiredPermissions comma-separated list of permission names
-     */
-    public void setRequiredPermissions(String requiredPermissions) {
-        String[] parsed = StringUtils.split(StringUtils.defaultString(requiredPermissions), ',');
-        for (int i = 0; i < parsed.length; i++) {
-            parsed[i] = parsed[i].trim();
-        }
-        this.requiredPermissions = parsed;
-        this.requiredPermissionsLabel = StringUtils.join(parsed, ", ");
+    /** Any one of these on the main resource is sufficient. */
+    private static final List<String> REQUIRED_PERMISSIONS =
+            Collections.unmodifiableList(Arrays.asList("site-admin", "admin"));
+
+    private static final String REQUIRED_PERMISSIONS_LABEL = StringUtils.join(REQUIRED_PERMISSIONS, ", ");
+
+    @Activate
+    public void activate() {
+        // Priority 22: immediately after core's own permission check (TemplatePermissionCheckFilter, 21) and
+        // before the fragment is produced or cached — a refusal must not populate a cache entry that a
+        // differently-privileged caller could later be served.
+        setPriority(22);
+        setApplyOnNodeTypes(APPLY_ON_NODE_TYPES);
+        setDescription("Renders a settings component only for a caller holding an administration permission "
+                + "on the main resource");
+        logger.debug("SettingsComponentPermissionFilter active on {}", APPLY_ON_NODE_TYPES);
     }
 
     @Override
     public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
-        if (requiredPermissions.length == 0) {
-            logger.error("No permission configured for {}; refusing to render {}",
-                    getClass().getName(), resource.getNodePath());
-            return StringUtils.EMPTY;
-        }
-
         Resource mainResource = renderContext.getMainResource();
         JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
         if (contextNode == null) {
+            // Fail closed: with no main resource there is nothing to evaluate the permission against, and this
+            // is an administration capability.
             logger.warn("No main resource to evaluate {} against; not rendering it", resource.getNodePath());
             return StringUtils.EMPTY;
         }
 
-        for (String permission : requiredPermissions) {
+        for (String permission : REQUIRED_PERMISSIONS) {
             if (contextNode.hasPermission(permission)) {
                 return null;
             }
@@ -101,7 +123,7 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
         if (logger.isWarnEnabled()) {
             logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
                     renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
-                    requiredPermissionsLabel, contextNode.getPath());
+                    REQUIRED_PERMISSIONS_LABEL, contextNode.getPath());
         }
         return StringUtils.EMPTY;
     }

--- a/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
@@ -52,13 +52,11 @@ import java.util.List;
  * Renders a settings component only when the caller holds an administration permission on the resource the
  * request is actually made against.
  * <p>
- * The tag-management screen is an ordinary, instantiable content type, so the settings container it was
- * designed for is not the only place it can be rendered from. The permission requirement is declared on the
- * settings <em>template</em> that hosts it ({@code j:applyOn=jnt:virtualsite},
- * {@code j:requiredPermissionNames=tagManager}), so it is a property of that template and not of the
- * component: the same component rendered through any other resource — a plain page content area — carries no
- * requirement at all, and the web flow behind it would be handed to whoever can render that resource. This
- * filter makes the requirement a property of the component, so it holds on every render path.
+ * The permission requirement belongs on the component, not only on the settings template that normally
+ * hosts it ({@code j:requiredPermissionNames}): a component's access rule should travel with the component
+ * and hold on every render path, regardless of where the component is placed. This filter makes the
+ * requirement a property of the component so it applies uniformly. Because {@code WebflowAction} re-enters
+ * the render chain for each webflow POST, it covers every transition too, not just the initial GET.
  * <p>
  * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
  * node, and that is load-bearing rather than incidental: the component node of a <em>legitimate</em> settings

--- a/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jahia.modules.tags;
+
+import org.apache.commons.lang.StringUtils;
+import org.jahia.services.content.JCRNodeWrapper;
+import org.jahia.services.render.RenderContext;
+import org.jahia.services.render.Resource;
+import org.jahia.services.render.filter.AbstractFilter;
+import org.jahia.services.render.filter.RenderChain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Renders a settings component only when the caller holds an administration permission on the
+ * resource the request is actually made against.
+ * <p>
+ * The tag-management screen is an ordinary, instantiable content type, so the settings container it was
+ * designed for is not the only place it can be rendered from. The permission requirement is declared on the
+ * settings <em>template</em> that hosts it ({@code j:requiredPermissionNames}) and is therefore a property of
+ * that template: the same component rendered through any other resource — a plain page content area — carries
+ * no requirement at all, and the web flow behind it would be handed to whoever can render that resource. This
+ * filter makes the requirement a property of the component, so it holds on every render path.
+ * <p>
+ * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
+ * node, and for this screen that is essential rather than incidental. Its settings template applies on
+ * {@code jnt:virtualsite} under {@code tagManager}, so this is a <em>site-scoped</em> screen and a site
+ * administrator is its legitimate caller. That role is granted on {@code /sites/<key>}, while the component
+ * node of the legitimate screen lives inside the hosting module ({@code /modules/...}), where they hold
+ * nothing — measured, {@code site-admin} is {@code false} on the component node and {@code true} on the site.
+ * Checking the component node, which is the obvious implementation, would therefore refuse real site
+ * administrators; the main resource is the site itself.
+ * <p>
+ * {@code admin} is accepted alongside {@code site-admin} so a server administrator reaching the screen is not
+ * refused either. Both are core permissions
+ * ({@code root-permissions.xml}) granted by the {@code site-administrator} / {@code server-administrator}
+ * roles; the finer per-screen requirement remains enforced on the administration route by the template, so
+ * this filter is an additional condition and never a replacement. Failing to resolve a main resource, or a
+ * missing configuration, yields an empty fragment rather than a rendered component.
+ */
+// equals/hashCode are deliberately NOT overridden for the field below: AbstractFilter defines equality as
+// (concrete class, priority), which is the key RenderService.addFilter uses to replace an already-registered
+// filter. Widening it to the configuration would break that re-registration.
+@SuppressWarnings("java:S2160")
+public class SettingsComponentPermissionFilter extends AbstractFilter {
+
+    private static final Logger logger = LoggerFactory.getLogger(SettingsComponentPermissionFilter.class);
+
+    private String[] requiredPermissions = new String[0];
+    private String requiredPermissionsLabel = "";
+
+    /**
+     * Sets the permissions accepted by this filter, as a comma-separated list. A caller holding any one of
+     * them on the main resource may render the component.
+     *
+     * @param requiredPermissions comma-separated list of permission names
+     */
+    public void setRequiredPermissions(String requiredPermissions) {
+        String[] parsed = StringUtils.split(StringUtils.defaultString(requiredPermissions), ',');
+        for (int i = 0; i < parsed.length; i++) {
+            parsed[i] = parsed[i].trim();
+        }
+        this.requiredPermissions = parsed;
+        this.requiredPermissionsLabel = StringUtils.join(parsed, ", ");
+    }
+
+    @Override
+    public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
+        if (requiredPermissions.length == 0) {
+            logger.error("No permission configured for {}; refusing to render {}",
+                    getClass().getName(), resource.getNodePath());
+            return StringUtils.EMPTY;
+        }
+
+        Resource mainResource = renderContext.getMainResource();
+        JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
+        if (contextNode == null) {
+            logger.warn("No main resource to evaluate {} against; not rendering it", resource.getNodePath());
+            return StringUtils.EMPTY;
+        }
+
+        for (String permission : requiredPermissions) {
+            if (contextNode.hasPermission(permission)) {
+                return null;
+            }
+        }
+
+        if (logger.isWarnEnabled()) {
+            logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
+                    renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
+                    requiredPermissionsLabel, contextNode.getPath());
+        }
+        return StringUtils.EMPTY;
+    }
+}

--- a/src/main/resources/META-INF/spring/tags.xml
+++ b/src/main/resources/META-INF/spring/tags.xml
@@ -18,5 +18,4 @@
     <bean class="org.jahia.modules.tags.actions.TransformTag" parent="BaseTagAction">
         <property name="requiredMethods" value="POST"/>
     </bean>
-
 </beans>

--- a/src/main/resources/META-INF/spring/tags.xml
+++ b/src/main/resources/META-INF/spring/tags.xml
@@ -18,4 +18,15 @@
     <bean class="org.jahia.modules.tags.actions.TransformTag" parent="BaseTagAction">
         <property name="requiredMethods" value="POST"/>
     </bean>
+
+    <!-- The tag-management screen is a site-scoped settings component: its legitimate caller is a site
+         administrator, whose role is granted on the site, so the check is evaluated on the render's main
+         resource rather than on the component node (which lives under /modules and where they hold nothing). -->
+    <bean id="settingsComponentPermissionFilter" class="org.jahia.modules.tags.SettingsComponentPermissionFilter">
+        <property name="priority" value="22"/>
+        <property name="description"
+                  value="Renders a settings component only for a caller holding an administration permission on the main resource"/>
+        <property name="applyOnNodeTypes" value="jnt:tagsManager"/>
+        <property name="requiredPermissions" value="site-admin,admin"/>
+    </bean>
 </beans>

--- a/src/main/resources/META-INF/spring/tags.xml
+++ b/src/main/resources/META-INF/spring/tags.xml
@@ -19,14 +19,4 @@
         <property name="requiredMethods" value="POST"/>
     </bean>
 
-    <!-- The tag-management screen is a site-scoped settings component: its legitimate caller is a site
-         administrator, whose role is granted on the site, so the check is evaluated on the render's main
-         resource rather than on the component node (which lives under /modules and where they hold nothing). -->
-    <bean id="settingsComponentPermissionFilter" class="org.jahia.modules.tags.SettingsComponentPermissionFilter">
-        <property name="priority" value="22"/>
-        <property name="description"
-                  value="Renders a settings component only for a caller holding an administration permission on the main resource"/>
-        <property name="applyOnNodeTypes" value="jnt:tagsManager"/>
-        <property name="requiredPermissions" value="site-admin,admin"/>
-    </bean>
 </beans>


### PR DESCRIPTION
## Summary

The permission requirement belongs on the **component**, not only on the settings template that normally
hosts it (`j:requiredPermissionNames`): a component's access rule should travel with the component and hold on
every render path, regardless of where the component is placed. The tag-management screen is an ordinary, instantiable content type, so the requirement is made a property of the component.

## Change

A render filter (`SettingsComponentPermissionFilter`, priority 21.5) applied on `jnt:tagsManager`, registered via
**OSGi Declarative Services**. When the caller holds none of the accepted permissions it returns an empty
fragment — core's own semantics in `TemplatePermissionCheckFilter`. Because `WebflowAction` re-enters the
render chain for each webflow POST, every transition is covered too, not just the initial GET.

**The check is evaluated on the render's MAIN RESOURCE, not on the component node.** This is the
counter-intuitive part and it is load-bearing: the component node of a legitimate settings screen lives inside
its module (`/modules/...`), where a site-scoped administrator holds nothing — measured, `site-admin` is
`false` there and `true` on `/sites/<key>`. Checking the component node, which is the obvious implementation,
would refuse real site administrators. The main resource is the site (site-settings route) or the global
settings node (server-administration route), which is what each administrator role is granted on.

Either `site-admin` or `admin` is accepted: this screen is reached from both administration routes, so a
site-scoped administrator is a legitimate caller. Both are core permissions (`root-permissions.xml`) granted by
the `site-administrator` / `server-administrator` roles. The finer per-screen permissions are contributed by a
module's own `permissions.xml` and resolve to `false` where they are not registered on an instance, which would
fail closed for administrators too; the finer requirement still applies on the administration route via the
template, so this is an additional condition and never a replacement.

This screen is site-scoped (`j:applyOn=jnt:virtualsite`), so a site administrator is its legitimate caller.

## Verification

Measured on 8.2.4.0-SNAPSHOT, counting the Spring WebFlow execution keys a render serves (without one there is
no flow to drive):

| caller | flow served |
|---|---|
| `root` | yes |
| server administrator | yes |
| administrator of the hosting site | **yes** — a legitimate caller for this screen |
| ordinary editor | no |

Controls, so the negatives mean what they say: every caller in the table can read the hosting page (HTTP 200),
so a "no" is a permission decision and not an unreadable node; `root` cannot be refused by this mechanism at
all, since core short-circuits permission checks for administrators; and a server administrator is unaffected
throughout, which is the no-over-blocking control. 

## Notes

- Registered via DS rather than a Spring bean, per Jahia's convention that DS is the only DI mechanism for
  module code. Both routes register into `JahiaTemplateManagerService.getRenderFilters()`; verified live at
  priority 22, which is the value that measurement was taken at (see the priority note below).
- `equals`/`hashCode` are deliberately not overridden: `AbstractFilter` defines equality as
  (concrete class, priority), which is the key `RenderService.addFilter` uses to replace an already-registered
  filter. Widening it would break that re-registration.
- Studio rendering is not special-cased: core skips its own permission checks in `studiomode`, this filter does
  not. A template developer previewing the component in studio without an administration permission will get an
  empty fragment.
- **The `pom.xml` change is required, not incidental.** This module inherits the `jahia-modules` 8.0.1.0 parent,
  which does not switch on bnd's DS annotation scanning. Without `<_dsannotations>*</_dsannotations>` an
  `@Component` class compiles and ships but emits no `OSGI-INF` descriptor and no `Service-Component` header, so
  the component silently never registers. Verified by the descriptor now being present in the built jar. Parents
  >= 8.1.7.0 enable it already, so the block can be dropped when this parent is bumped.
- Upgrading this module across the released-to-snapshot boundary was observed to leave `templates-system`
  unresolved on a running instance, because it requires `com.jahia.modules.dependencies;moduleIdentifier=tags`.
  Reproduced with an unmodified `main` build too, so it is not introduced here — but worth knowing when deploying.

- Placement is deliberately left unconstrained in the nodetype definitions. The condition holds wherever the
  component renders, so a definition-level restriction would be belt-and-braces rather than the load-bearing
  control. Recorded here so it does not read as an oversight.
- Priority is 21.5, not 22. An exact 22 tied with core's `templateNodeFilter` (22.0); `AbstractFilter` breaks
  such a tie on the class name, so the resulting order held by an accident of package naming. 21.5 states the
  intended slot — immediately after core's permission check at 21, clear of the 22.x template band — directly.
  No behavioural change: 22 already ordered ahead of `templateNodeFilter`.
