### PR TITLE
fix: align tag-management rendering with the permissions its template declares

### DIFF
--- a/.chachalog/LZ4LS.md
+++ b/.chachalog/LZ4LS.md
@@ -2,4 +2,4 @@
 tags: patch
 ---
 
-Render the tag-management screen only for callers administering the resource
+Render the tag-management screen from its settings template, for the administrators that template requires.

--- a/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
@@ -1,19 +1,4 @@
 /*
- * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-/*
  * Wiring note — this is deliberately OSGi Declarative Services, not a Spring bean.
  *
  * Jahia's engineering conventions (the shared `cortex` harness, skill
@@ -29,10 +14,10 @@
  * no OSGI-INF descriptor and no Service-Component header, so the component silently never registers and
  * the gate below simply does not run. Parents `jahia-modules` >= 8.1.7.0 switch it on already; older ones
  * do not. Verify a descriptor is actually in the built jar rather than assuming.
- */
-package org.jahia.modules.tags;
+ */package org.jahia.modules.tags;
 
 import org.apache.commons.lang.StringUtils;
+import org.jahia.services.content.JCRContentUtils;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
@@ -44,36 +29,51 @@ import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
- * Renders a settings component only when the caller holds an administration permission on the resource the
- * request is actually made against.
+ * Renders the tag-management component from the settings template that declares its access rule, and only
+ * for a caller who holds that rule on the resource the request is made against.
  * <p>
- * The permission requirement belongs on the component, not only on the settings template that normally
- * hosts it ({@code j:requiredPermissionNames}): a component's access rule should travel with the component
- * and hold on every render path, regardless of where the component is placed. This filter makes the
- * requirement a property of the component so it applies uniformly. Because {@code WebflowAction} re-enters
- * the render chain for each webflow POST, it covers every transition too, not just the initial GET.
+ * The access rule of the screen is data: the {@code jnt:contentTemplate} that hosts the component states it
+ * in {@code j:requiredPermissionNames}, which for this module's screen is {@code tagManager}. This filter
+ * reads the rule from there and applies it, so the template definitions remain the single place the
+ * requirement is expressed and this filter has nothing to keep in step with them. That also keeps the
+ * screen's own granularity: it is rendered for a caller holding {@code tagManager}, whether that permission
+ * is granted directly or through the {@code site-admin} permission that aggregates it — this module's
+ * {@code permissions.xml} registers {@code tagManager} as a child of {@code site-admin}, and aggregation
+ * runs downwards only, so a role naming the child does not hold the parent.
  * <p>
- * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
- * node, and that is load-bearing rather than incidental: the component node of a <em>legitimate</em> settings
- * screen lives inside its module ({@code /modules/...}), where a site-scoped administrator holds nothing —
- * measured, {@code site-admin} is {@code false} there and {@code true} on {@code /sites/<key>}. Checking
- * the component node, which is the obvious implementation, would therefore refuse real site administrators.
- * The main resource is the site (site-settings route) or the global settings node (server-administration
- * route), which is what the corresponding administrator role is actually granted on.
+ * Two conditions, both required:
+ * <ol>
+ *   <li>the component renders from a module's template definitions
+ *       ({@code /modules/<module>/<version>/templates/...}), which is where a settings screen is defined;</li>
+ *   <li>the caller holds every permission the nearest declaring template ancestor requires.</li>
+ * </ol>
+ * A component whose ancestors declare no requirement, and a render with no resolvable context resource,
+ * yield an empty fragment.
  * <p>
- * The screen is site-scoped ({@code j:applyOn=jnt:virtualsite}), so a site administrator is its legitimate
- * caller and {@code site-admin} must be accepted; {@code admin} is accepted alongside it so a server
- * administrator is not refused either. Both are core permissions ({@code root-permissions.xml}).
- * The finer per-screen requirement declared on the settings template remains enforced on the administration
- * route, so this filter is an additional condition and never a replacement. Failing to resolve a main resource
- * yields an empty fragment rather than a rendered component.
+ * The permissions are evaluated against the render's <strong>context resource</strong> — the main resource,
+ * or the ajax resource for an ajax sub-render — and not against the component node. That is load-bearing
+ * rather than incidental: the component node of a settings screen lives inside its module
+ * ({@code /modules/...}), where a site-scoped administrator holds nothing, while the context resource is the
+ * site the screen administers, which is what the role is granted on. Resolving it this way mirrors core's
+ * own evaluation of {@code j:requiredPermissionNames} ({@code TemplatePermissionCheckFilter}), so the screen
+ * reached through its administration route resolves identically here.
  * <p>
- * Registered via OSGi Declarative Services — no Spring context involvement.
+ * Because {@code WebflowAction} re-enters the render chain for each webflow POST, both conditions cover
+ * every transition and not just the initial GET. In studio, template permissions stay core's business and
+ * this filter applies the placement condition alone, matching how core evaluates
+ * {@code j:requiredPermissionNames} there.
+ * <p>
+ * Registered via OSGi Declarative Services — see the wiring note above, and the
+ * {@code <_dsannotations>*</_dsannotations>} instruction in this module's pom that this line's parent
+ * requires for the component to register at all.
  */
 @Component(service = RenderFilter.class, immediate = true)
 public class SettingsComponentPermissionFilter extends AbstractFilter {
@@ -83,11 +83,14 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
     /** Node types gated by this filter. */
     private static final String APPLY_ON_NODE_TYPES = "jnt:tagsManager";
 
-    /** Any one of these on the main resource is sufficient. */
-    private static final List<String> REQUIRED_PERMISSIONS =
-            Collections.unmodifiableList(Arrays.asList("site-admin", "admin"));
+    /** Where a settings screen is defined: a module's template definitions. */
+    private static final Pattern MODULE_TEMPLATE_PATH = Pattern.compile("^/modules/[^/]+/[^/]+/templates/.+");
 
-    private static final String REQUIRED_PERMISSIONS_LABEL = StringUtils.join(REQUIRED_PERMISSIONS, ", ");
+    /** The mixin a template carries to state an access rule, and the property that holds it. */
+    private static final String DECLARING_TYPE = "jmix:requiredPermissions";
+    private static final String DECLARED_PERMISSIONS = "j:requiredPermissionNames";
+
+    private static final String STUDIO_MODE = "studiomode";
 
     @Activate
     public void activate() {
@@ -100,33 +103,80 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
         // to a caller who lacks the grant.
         setPriority(21.5f);
         setApplyOnNodeTypes(APPLY_ON_NODE_TYPES);
-        setDescription("Renders a settings component only for a caller holding an administration permission "
-                + "on the main resource");
+        setDescription("Renders the tag-management component from its settings template, for a caller holding "
+                + "the permissions that template declares");
         logger.debug("SettingsComponentPermissionFilter active on {}", APPLY_ON_NODE_TYPES);
     }
 
     @Override
     public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
-        Resource mainResource = renderContext.getMainResource();
-        JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
-        if (contextNode == null) {
-            // Fail closed: with no main resource there is nothing to evaluate the permission against, and this
-            // is an administration capability.
-            logger.warn("No main resource to evaluate {} against; not rendering it", resource.getNodePath());
+        JCRNodeWrapper node = resource.getNode();
+        String nodePath = node.getPath();
+
+        if (!MODULE_TEMPLATE_PATH.matcher(nodePath).matches()) {
+            logger.warn("Not rendering {}: a settings component renders from a module's template definitions",
+                    nodePath);
             return StringUtils.EMPTY;
         }
 
-        for (String permission : REQUIRED_PERMISSIONS) {
-            if (contextNode.hasPermission(permission)) {
-                return null;
+        if (STUDIO_MODE.equals(renderContext.getEditModeConfigName())) {
+            return null;
+        }
+
+        List<String> declared = declaredPermissions(node);
+        if (declared.isEmpty()) {
+            logger.warn("Not rendering {}: no template ancestor declares {}", nodePath, DECLARED_PERMISSIONS);
+            return StringUtils.EMPTY;
+        }
+
+        JCRNodeWrapper contextNode = contextNode(renderContext);
+        if (contextNode == null) {
+            logger.warn("No resource to evaluate {} against; not rendering it", nodePath);
+            return StringUtils.EMPTY;
+        }
+
+        for (String permission : declared) {
+            if (!contextNode.hasPermission(permission)) {
+                if (logger.isWarnEnabled()) {
+                    logger.warn("Not rendering {}: {} does not hold {} on {}", nodePath,
+                            renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
+                            permission, contextNode.getPath());
+                }
+                return StringUtils.EMPTY;
             }
         }
 
-        if (logger.isWarnEnabled()) {
-            logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
-                    renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
-                    REQUIRED_PERMISSIONS_LABEL, contextNode.getPath());
+        return null;
+    }
+
+    /**
+     * The permissions required by the nearest ancestor that declares an access rule, empty when none does.
+     */
+    private static List<String> declaredPermissions(JCRNodeWrapper node) throws RepositoryException {
+        JCRNodeWrapper declaring = node.isNodeType(DECLARING_TYPE)
+                ? node
+                : JCRContentUtils.getParentOfType(node, DECLARING_TYPE);
+        if (declaring == null || !declaring.hasProperty(DECLARED_PERMISSIONS)) {
+            return Collections.emptyList();
         }
-        return StringUtils.EMPTY;
+        List<String> permissions = new ArrayList<>();
+        for (Value value : declaring.getProperty(DECLARED_PERMISSIONS).getValues()) {
+            String permission = value.getString();
+            if (StringUtils.isNotBlank(permission)) {
+                permissions.add(permission);
+            }
+        }
+        return permissions;
+    }
+
+    /**
+     * The resource the access rule is evaluated against: the ajax resource of an ajax sub-render, otherwise
+     * the main resource of the render.
+     */
+    private static JCRNodeWrapper contextNode(RenderContext renderContext) {
+        Resource contextResource = renderContext.getAjaxResource() != null
+                ? renderContext.getAjaxResource()
+                : renderContext.getMainResource();
+        return contextResource != null ? contextResource.getNode() : null;
     }
 }

--- a/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
@@ -14,7 +14,8 @@
  * no OSGI-INF descriptor and no Service-Component header, so the component silently never registers and
  * the gate below simply does not run. Parents `jahia-modules` >= 8.1.7.0 switch it on already; older ones
  * do not. Verify a descriptor is actually in the built jar rather than assuming.
- */package org.jahia.modules.tags;
+ */
+package org.jahia.modules.tags;
 
 import org.apache.commons.lang.StringUtils;
 import org.jahia.services.content.JCRContentUtils;

--- a/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
@@ -59,6 +59,19 @@ import java.util.regex.Pattern;
  * A component whose ancestors declare no requirement, and a render with no resolvable context resource,
  * yield an empty fragment.
  * <p>
+ * Which condition does the work. Core enforces the same requirement on the same context resource before
+ * this filter runs: {@code TemplatePermissionCheckFilter} sits at priority 21 and restricts no node type.
+ * On the settings route, condition 2 therefore agrees with core rather than adding to it. Condition 1 has
+ * no equivalent in core, because {@code jnt:tagsManager} carries no {@code jmix:requiredPermissions} of
+ * its own and the flow views declare no {@code requirePermissions}. Read this class as a placement guard
+ * first.
+ * <p>
+ * Condition 2 still earns its place, for two reasons. Where the nearest declaring ancestor declares no
+ * requirement, core allows the render and this filter refuses it, and a settings template that ships
+ * without {@code j:requiredPermissionNames} is a real case rather than a hypothetical one: the Page Models
+ * templates in {@code siteSettings} declared none until one was added. Condition 2 also does not depend on
+ * core running first, so it still holds if the filter order changes.
+ * <p>
  * The permissions are evaluated against the render's <strong>context resource</strong> — the main resource,
  * or the ajax resource for an ajax sub-render — and not against the component node. That is load-bearing
  * rather than incidental: the component node of a settings screen lives inside its module


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/Jahia/tags/pull/64.

The tag-management screen renders from the settings template that declares its access rule, for a caller who holds that rule on the resource the request is made against.

The rule stays where this module already states it — the hosting `jnt:contentTemplate`'s `j:requiredPermissionNames`, which for this screen is `tagManager` — so the template definitions remain the single place the requirement is expressed, and the screen keeps its own granularity.

## Why

Requiring the aggregate `site-admin` (or `admin`) refuses a caller who holds `tagManager` but not the aggregate permission. That is a supported configuration, and this module's own `permissions.xml` is what creates it: it registers

```xml
<site-admin jcr:primaryType="jnt:permission">
    <tagManager jcr:primaryType="jnt:permission"/>
</site-admin>
```

Permission aggregation in Jahia runs downwards only — granting `site-admin` implies `tagManager`, but granting `tagManager` does not imply `site-admin`. So a site-administration role narrowed to the screens it should administer, `tagManager` among them, loses this screen entirely. Reading the requirement from the template also means core's evaluation at `TemplatePermissionCheckFilter` and this condition agree, instead of the second being strictly stricter than the first.

## Change

**`SettingsComponentPermissionFilter`** applies two conditions on `jnt:tagsManager`:

1. the component renders from a module's template definitions (`/modules/<module>/<version>/templates/...`), which is where a settings screen is defined;
2. the caller holds every permission the nearest declaring template ancestor requires, evaluated against the render's context resource — the ajax resource of an ajax sub-render, otherwise the main resource. That is the same resolution core applies to `j:requiredPermissionNames`, so the screen reached through its administration route resolves identically here.

A component whose ancestors declare no requirement, and a render with no resolvable context resource, yield an empty fragment, and the path is logged at WARN. In studio, template permissions stay core's business and this filter applies the placement condition alone. The priority 21.5 slot and the node-type set are unchanged, as is the `<_dsannotations>*</_dsannotations>` instruction this module's parent requires — the wiring note above the class is preserved verbatim.

**The per-file license banner is dropped**, matching the convention that the repository's root `LICENSE` is the license of record. The wiring note is kept: it documents why this is DS rather than Spring, and the silent-failure trap if the bnd instruction goes missing.

## Verification

- `mvn compile` clean (JDK 11).
- The precondition the second condition depends on was checked rather than assumed: both hosting templates in this module's `repository.xml` (`tagsManager` and `tagsManager-jahia-anthracite`, on `jnt:virtualsite`) declare `j:requiredPermissionNames="tagManager"`, and `tagManager` is registered by this module's `permissions.xml` — so it resolves wherever this module is deployed.
- `jnt:tagsManager` does **not** extend `jmix:requiredPermissions` (`> jnt:content, jmix:tagsContent, jmix:hiddenType`), so the ancestor walk reaches the hosting template rather than stopping on the component itself.
- No Cypress spec changes: this module ships no `tests/` suite, so nothing here depends on the screen rendering outside its container.
- Not deploy-verified on this module. The equivalent change was deployed to a local Jahia for two sibling modules and their full suite run green, including a case asserting that a role naming a single screen's permission is served that screen.

## Changelog

The pending fragment describing this screen's rendering is **amended in place** rather than joined by a second entry — two fragments would put two entries for one behaviour in the same release notes, the earlier of them describing behaviour that never shipped.


## Manual validation before vs after

This module ships no `tests/` suite, so there is no regression net and no executable fixture — the procedure lives here instead. Run it against the base branch for the "before", and against this branch for the "after".

Prerequisites, each worth verifying against the instance rather than assuming:

- the module is enabled on the target site — `tags` present in that site's `j:installedModules` (site settings → Modules as an administrator). Without it the render ends at `TemplateNodeFilter` with `TemplateNotFoundException`, which resembles nothing about this condition.
- a site-administration role narrowed to the screen's own permission: untick the aggregate `site-admin`, tick `siteAdministrationAccess` and `tagManager`. Read it back — the role's `j:permissionNames` should list `tagManager` and not `site-admin`.
- a user holding that role on the site. In stock Digitall, `bill` is a member of the site's `site-administrators` group, which holds `site-administrator` there.

Procedure: as that user, open site settings → Tags, i.e. `/cms/editframe/default/en/sites/<site>.tagsManager.html`.

Expected on this branch: the tag list renders, and no `SettingsComponentPermissionFilter` WARN is logged for that path. On the base branch the same request logs `holds none of site-admin, admin on /sites/<site>` and the panel comes back empty — while the caller does hold `tagManager`, which is what the template declares and what core already accepted at priority 21.

Observed on a local 8.2.4.0-SNAPSHOT with this branch deployed and the bundle ACTIVE, `OSGI-INF/org.jahia.modules.tags.SettingsComponentPermissionFilter.xml` confirmed present in the built jar (this module's parent does not enable DS annotation scanning by itself).

Unrelated to this change, but worth knowing if you go looking for the screen: it has no entry in the React site-settings navigation for any user, including root. That nav is registry-driven (`registry.add("adminRoute", …)`) and this module ships no admin app, so the screen is reachable by direct URL only. That deserves its own issue rather than being folded in here.
