### PR TITLE
revert: "fix: align tag-management rendering with the permissions its template declares" (#67)

### DIFF
--- a/.chachalog/LZ4LS.md
+++ b/.chachalog/LZ4LS.md
@@ -2,4 +2,4 @@
 tags: patch
 ---
 
-Render the tag-management screen from its settings template, for the administrators that template requires.
+Render the tag-management screen only for callers administering the resource

--- a/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
+++ b/src/main/java/org/jahia/modules/tags/SettingsComponentPermissionFilter.java
@@ -1,4 +1,19 @@
 /*
+ * Copyright (C) 2002-2022 Jahia Solutions Group SA. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * Wiring note — this is deliberately OSGi Declarative Services, not a Spring bean.
  *
  * Jahia's engineering conventions (the shared `cortex` harness, skill
@@ -18,7 +33,6 @@
 package org.jahia.modules.tags;
 
 import org.apache.commons.lang.StringUtils;
-import org.jahia.services.content.JCRContentUtils;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
@@ -30,64 +44,36 @@ import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jcr.RepositoryException;
-import javax.jcr.Value;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
- * Renders the tag-management component from the settings template that declares its access rule, and only
- * for a caller who holds that rule on the resource the request is made against.
+ * Renders a settings component only when the caller holds an administration permission on the resource the
+ * request is actually made against.
  * <p>
- * The access rule of the screen is data: the {@code jnt:contentTemplate} that hosts the component states it
- * in {@code j:requiredPermissionNames}, which for this module's screen is {@code tagManager}. This filter
- * reads the rule from there and applies it, so the template definitions remain the single place the
- * requirement is expressed and this filter has nothing to keep in step with them. That also keeps the
- * screen's own granularity: it is rendered for a caller holding {@code tagManager}, whether that permission
- * is granted directly or through the {@code site-admin} permission that aggregates it — this module's
- * {@code permissions.xml} registers {@code tagManager} as a child of {@code site-admin}, and aggregation
- * runs downwards only, so a role naming the child does not hold the parent.
+ * The permission requirement belongs on the component, not only on the settings template that normally
+ * hosts it ({@code j:requiredPermissionNames}): a component's access rule should travel with the component
+ * and hold on every render path, regardless of where the component is placed. This filter makes the
+ * requirement a property of the component so it applies uniformly. Because {@code WebflowAction} re-enters
+ * the render chain for each webflow POST, it covers every transition too, not just the initial GET.
  * <p>
- * Two conditions, both required:
- * <ol>
- *   <li>the component renders from a module's template definitions
- *       ({@code /modules/<module>/<version>/templates/...}), which is where a settings screen is defined;</li>
- *   <li>the caller holds every permission the nearest declaring template ancestor requires.</li>
- * </ol>
- * A component whose ancestors declare no requirement, and a render with no resolvable context resource,
- * yield an empty fragment.
+ * The check is evaluated against the <strong>main resource</strong> of the render, not against the component
+ * node, and that is load-bearing rather than incidental: the component node of a <em>legitimate</em> settings
+ * screen lives inside its module ({@code /modules/...}), where a site-scoped administrator holds nothing —
+ * measured, {@code site-admin} is {@code false} there and {@code true} on {@code /sites/<key>}. Checking
+ * the component node, which is the obvious implementation, would therefore refuse real site administrators.
+ * The main resource is the site (site-settings route) or the global settings node (server-administration
+ * route), which is what the corresponding administrator role is actually granted on.
  * <p>
- * Which condition does the work. Core enforces the same requirement on the same context resource before
- * this filter runs: {@code TemplatePermissionCheckFilter} sits at priority 21 and restricts no node type.
- * On the settings route, condition 2 therefore agrees with core rather than adding to it. Condition 1 has
- * no equivalent in core, because {@code jnt:tagsManager} carries no {@code jmix:requiredPermissions} of
- * its own and the flow views declare no {@code requirePermissions}. Read this class as a placement guard
- * first.
+ * The screen is site-scoped ({@code j:applyOn=jnt:virtualsite}), so a site administrator is its legitimate
+ * caller and {@code site-admin} must be accepted; {@code admin} is accepted alongside it so a server
+ * administrator is not refused either. Both are core permissions ({@code root-permissions.xml}).
+ * The finer per-screen requirement declared on the settings template remains enforced on the administration
+ * route, so this filter is an additional condition and never a replacement. Failing to resolve a main resource
+ * yields an empty fragment rather than a rendered component.
  * <p>
- * Condition 2 still earns its place, for two reasons. Where the nearest declaring ancestor declares no
- * requirement, core allows the render and this filter refuses it, and a settings template that ships
- * without {@code j:requiredPermissionNames} is a real case rather than a hypothetical one: the Page Models
- * templates in {@code siteSettings} declared none until one was added. Condition 2 also does not depend on
- * core running first, so it still holds if the filter order changes.
- * <p>
- * The permissions are evaluated against the render's <strong>context resource</strong> — the main resource,
- * or the ajax resource for an ajax sub-render — and not against the component node. That is load-bearing
- * rather than incidental: the component node of a settings screen lives inside its module
- * ({@code /modules/...}), where a site-scoped administrator holds nothing, while the context resource is the
- * site the screen administers, which is what the role is granted on. Resolving it this way mirrors core's
- * own evaluation of {@code j:requiredPermissionNames} ({@code TemplatePermissionCheckFilter}), so the screen
- * reached through its administration route resolves identically here.
- * <p>
- * Because {@code WebflowAction} re-enters the render chain for each webflow POST, both conditions cover
- * every transition and not just the initial GET. In studio, template permissions stay core's business and
- * this filter applies the placement condition alone, matching how core evaluates
- * {@code j:requiredPermissionNames} there.
- * <p>
- * Registered via OSGi Declarative Services — see the wiring note above, and the
- * {@code <_dsannotations>*</_dsannotations>} instruction in this module's pom that this line's parent
- * requires for the component to register at all.
+ * Registered via OSGi Declarative Services — no Spring context involvement.
  */
 @Component(service = RenderFilter.class, immediate = true)
 public class SettingsComponentPermissionFilter extends AbstractFilter {
@@ -97,14 +83,11 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
     /** Node types gated by this filter. */
     private static final String APPLY_ON_NODE_TYPES = "jnt:tagsManager";
 
-    /** Where a settings screen is defined: a module's template definitions. */
-    private static final Pattern MODULE_TEMPLATE_PATH = Pattern.compile("^/modules/[^/]+/[^/]+/templates/.+");
+    /** Any one of these on the main resource is sufficient. */
+    private static final List<String> REQUIRED_PERMISSIONS =
+            Collections.unmodifiableList(Arrays.asList("site-admin", "admin"));
 
-    /** The mixin a template carries to state an access rule, and the property that holds it. */
-    private static final String DECLARING_TYPE = "jmix:requiredPermissions";
-    private static final String DECLARED_PERMISSIONS = "j:requiredPermissionNames";
-
-    private static final String STUDIO_MODE = "studiomode";
+    private static final String REQUIRED_PERMISSIONS_LABEL = StringUtils.join(REQUIRED_PERMISSIONS, ", ");
 
     @Activate
     public void activate() {
@@ -117,80 +100,33 @@ public class SettingsComponentPermissionFilter extends AbstractFilter {
         // to a caller who lacks the grant.
         setPriority(21.5f);
         setApplyOnNodeTypes(APPLY_ON_NODE_TYPES);
-        setDescription("Renders the tag-management component from its settings template, for a caller holding "
-                + "the permissions that template declares");
+        setDescription("Renders a settings component only for a caller holding an administration permission "
+                + "on the main resource");
         logger.debug("SettingsComponentPermissionFilter active on {}", APPLY_ON_NODE_TYPES);
     }
 
     @Override
     public String prepare(RenderContext renderContext, Resource resource, RenderChain chain) throws Exception {
-        JCRNodeWrapper node = resource.getNode();
-        String nodePath = node.getPath();
-
-        if (!MODULE_TEMPLATE_PATH.matcher(nodePath).matches()) {
-            logger.warn("Not rendering {}: a settings component renders from a module's template definitions",
-                    nodePath);
-            return StringUtils.EMPTY;
-        }
-
-        if (STUDIO_MODE.equals(renderContext.getEditModeConfigName())) {
-            return null;
-        }
-
-        List<String> declared = declaredPermissions(node);
-        if (declared.isEmpty()) {
-            logger.warn("Not rendering {}: no template ancestor declares {}", nodePath, DECLARED_PERMISSIONS);
-            return StringUtils.EMPTY;
-        }
-
-        JCRNodeWrapper contextNode = contextNode(renderContext);
+        Resource mainResource = renderContext.getMainResource();
+        JCRNodeWrapper contextNode = mainResource != null ? mainResource.getNode() : null;
         if (contextNode == null) {
-            logger.warn("No resource to evaluate {} against; not rendering it", nodePath);
+            // Fail closed: with no main resource there is nothing to evaluate the permission against, and this
+            // is an administration capability.
+            logger.warn("No main resource to evaluate {} against; not rendering it", resource.getNodePath());
             return StringUtils.EMPTY;
         }
 
-        for (String permission : declared) {
-            if (!contextNode.hasPermission(permission)) {
-                if (logger.isWarnEnabled()) {
-                    logger.warn("Not rendering {}: {} does not hold {} on {}", nodePath,
-                            renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
-                            permission, contextNode.getPath());
-                }
-                return StringUtils.EMPTY;
+        for (String permission : REQUIRED_PERMISSIONS) {
+            if (contextNode.hasPermission(permission)) {
+                return null;
             }
         }
 
-        return null;
-    }
-
-    /**
-     * The permissions required by the nearest ancestor that declares an access rule, empty when none does.
-     */
-    private static List<String> declaredPermissions(JCRNodeWrapper node) throws RepositoryException {
-        JCRNodeWrapper declaring = node.isNodeType(DECLARING_TYPE)
-                ? node
-                : JCRContentUtils.getParentOfType(node, DECLARING_TYPE);
-        if (declaring == null || !declaring.hasProperty(DECLARED_PERMISSIONS)) {
-            return Collections.emptyList();
+        if (logger.isWarnEnabled()) {
+            logger.warn("Not rendering {}: {} holds none of {} on {}", resource.getNodePath(),
+                    renderContext.getUser() != null ? renderContext.getUser().getName() : "the current user",
+                    REQUIRED_PERMISSIONS_LABEL, contextNode.getPath());
         }
-        List<String> permissions = new ArrayList<>();
-        for (Value value : declaring.getProperty(DECLARED_PERMISSIONS).getValues()) {
-            String permission = value.getString();
-            if (StringUtils.isNotBlank(permission)) {
-                permissions.add(permission);
-            }
-        }
-        return permissions;
-    }
-
-    /**
-     * The resource the access rule is evaluated against: the ajax resource of an ajax sub-render, otherwise
-     * the main resource of the render.
-     */
-    private static JCRNodeWrapper contextNode(RenderContext renderContext) {
-        Resource contextResource = renderContext.getAjaxResource() != null
-                ? renderContext.getAjaxResource()
-                : renderContext.getMainResource();
-        return contextResource != null ? contextResource.getNode() : null;
+        return StringUtils.EMPTY;
     }
 }


### PR DESCRIPTION
## Summary

Reverts [Jahia/tags#67](https://github.com/Jahia/tags/pull/67). The approach behind it is being reconsidered, so the change is withdrawn from this line rather than adjusted.

## What this restores

The settings component condition returns to requiring the aggregate permission. Any template data and test changes that came with it return to their previous form.

## Note for whoever merges this

This restores a known behaviour: a role that names a per-screen permission, without the aggregate one, is refused the corresponding screen. That is intended here. The change is withdrawn whole, and the follow-up belongs to the new approach.

Merge order matters. The change reverted here sits on top of the original condition, so this revert should land before any revert of that original change. Otherwise the later revert has to undo code that this one already rewrote.

## Verification

`git revert` applied with no conflict. The state after the revert was checked against the state before the reverted change, not assumed.
